### PR TITLE
Add contourpy 1.0.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,7 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
-  license_family: https://github.com/contourpy/contourpy/blob/main/LICENSE
+  license_url: https://github.com/contourpy/contourpy/blob/main/LICENSE
   description: |
     ContourPy is a Python library for calculating contours of 2D quadrilateral
     grids.  It is written in C++11 and wrapped using pybind11.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,38 +17,41 @@ build:
 requirements:
   build:
     - {{ compiler('cxx') }}
-    - cross-python_{{ target_platform }}  # [build_platform != target_platform]
-    - pybind11 >=2.6                      # [build_platform != target_platform]
-    - python                              # [build_platform != target_platform]
   host:
-    - build
+    - python
+    # python-build is the 'build' package https://pypi.org/project/build/
+    - python-build
     - pip
     - pybind11 >=2.6
-    - python
     - setuptools >=42
+    - wheel
   run:
-    - numpy >=1.16
     - python
+    - numpy >=1.16
 
 test:
   imports:
     - contourpy
     - contourpy.util
+  requires:
+    - pip
   commands:
     - pip check
     - python -c "import contourpy as c; c.contour_generator(z=[[0, 1], [2, 3]]).lines(0.9)"
-  requires:
-    - pip
 
 about:
+  home: https://github.com/contourpy/contourpy
+  summary: Python library for calculating contours of 2D quadrilateral grids.
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  license_family: https://github.com/contourpy/contourpy/blob/main/LICENSE
   description: |
     ContourPy is a Python library for calculating contours of 2D quadrilateral
     grids.  It is written in C++11 and wrapped using pybind11.
   doc_url: https://contourpy.readthedocs.io
-  home: https://github.com/contourpy/contourpy
-  summary: Python library for calculating contours of 2D quadrilateral grids.
-  license: BSD-3-Clause
-  license_file: LICENSE
+  doc_sourc_url: https://github.com/contourpy/contourpy/tree/main/docs
+  dev_url: https://github.com/contourpy/contourpy
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Changelog: https://github.com/contourpy/contourpy/blob/v1.0.5/docs/changelog.rst
License: https://github.com/contourpy/contourpy/blob/v1.0.5/LICENSE
Requirements:
- https://github.com/contourpy/contourpy/blob/v1.0.5/pyproject.toml
- https://github.com/contourpy/contourpy/blob/v1.0.5/setup.cfg
- https://github.com/contourpy/contourpy/blob/v1.0.5/setup.py


Actions:
1. Rename the package `build` to `python-build` and add a comment.
2. Add `wheel`.
3. Add `dev_url`, `doc_url`, `doc_source_url`, `licence_url`, and `license_family`.