### PR TITLE
Update to contourpy 1.2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,17 +12,17 @@ source:
 build:
   number: 0
   skip: true  # [py<39]
-  script: {{ PYTHON }} -m pip install . -vv --no-build-isolation
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   build:
     - {{ compiler('cxx') }}
+    - ninja 1.10.2
   host:
     - pip
-    - meson >=1.2.0
-    - meson-python >=0.13.1
-    - ninja >=1.8.2
-    - pybind11 >=2.10.4
+    - meson ==1.2.1
+    - meson-python ==0.13.1
+    - pybind11 ==2.10.4
     - python
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,8 +17,8 @@ build:
 requirements:
   build:
     - {{ compiler('cxx') }}
-    - ninja 1.10.2
   host:
+    - ninja
     - pip
     - meson ==1.2.1
     - meson-python ==0.13.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,6 @@ requirements:
   build:
     - {{ compiler('cxx') }}
   host:
-    - ninja
     - pip
     - meson ==1.2.1
     - meson-python ==0.13.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,14 +19,14 @@ requirements:
     - cross-python_{{ target_platform }}  # [build_platform != target_platform]
     - meson >=1.2.0                       # [build_platform != target_platform]
     - meson-python >=0.13.1               # [build_platform != target_platform]
-    - ninja                               # [build_platform != target_platform]
+    - ninja >=1.8.2                       # [build_platform != target_platform]
     - pybind11 >=2.10.4                   # [build_platform != target_platform]
     - python                              # [build_platform != target_platform]
   host:
     - pip
     - meson >=1.2.0
     - meson-python >=0.13.1
-    - ninja
+    - ninja >=1.8.2
     - pybind11 >=2.10.4
     - python
   run:
@@ -51,7 +51,6 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
-  license_url: https://github.com/contourpy/contourpy/blob/main/LICENSE
   description: |
     ContourPy is a Python library for calculating contours of 2D quadrilateral
     grids.  It is written in C++11 and wrapped using pybind11.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,16 +12,11 @@ source:
 build:
   number: 0
   skip: true  # [py<39]
+  script: {{ PYTHON }} -m pip install . -vv --no-build-isolation
 
 requirements:
   build:
     - {{ compiler('cxx') }}
-    - cross-python_{{ target_platform }}  # [build_platform != target_platform]
-    - meson >=1.2.0                       # [build_platform != target_platform]
-    - meson-python >=0.13.1               # [build_platform != target_platform]
-    - ninja >=1.8.2                       
-    - pybind11 >=2.10.4                   # [build_platform != target_platform]
-    - python                              # [build_platform != target_platform]
   host:
     - pip
     - meson >=1.2.0
@@ -30,8 +25,8 @@ requirements:
     - pybind11 >=2.10.4
     - python
   run:
-    - numpy >=1.20,<2
     - python
+    - numpy >=1.20,<2
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - cross-python_{{ target_platform }}  # [build_platform != target_platform]
     - meson >=1.2.0                       # [build_platform != target_platform]
     - meson-python >=0.13.1               # [build_platform != target_platform]
-    - ninja >=1.8.2                       # [build_platform != target_platform]
+    - ninja >=1.8.2                       
     - pybind11 >=2.10.4                   # [build_platform != target_platform]
     - python                              # [build_platform != target_platform]
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "contourpy" %}
-{% set version = "1.0.5" %}
+{% set version = "1.2.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,37 +7,43 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/contourpy-{{ version }}.tar.gz
-  sha256: 896631cd40222aef3697e4e51177d14c3709fda49d30983269d584f034acc8a4
+  sha256: 171f311cb758de7da13fc53af221ae47a5877be5a0843a9fe150818c51ed276a
 
 build:
   number: 0
-  skip: true  # [py<37]
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: true  # [py<39]
 
 requirements:
   build:
     - {{ compiler('cxx') }}
+    - cross-python_{{ target_platform }}  # [build_platform != target_platform]
+    - meson >=1.2.0                       # [build_platform != target_platform]
+    - meson-python >=0.13.1               # [build_platform != target_platform]
+    - ninja                               # [build_platform != target_platform]
+    - pybind11 >=2.10.4                   # [build_platform != target_platform]
+    - python                              # [build_platform != target_platform]
   host:
-    - python
-    # python-build is the 'build' package https://pypi.org/project/build/
-    - python-build
     - pip
-    - pybind11 >=2.6
-    - setuptools >=42
-    - wheel
-  run:
+    - meson >=1.2.0
+    - meson-python >=0.13.1
+    - ninja
+    - pybind11 >=2.10.4
     - python
-    - numpy >=1.16
+  run:
+    - numpy >=1.20,<2
+    - python
 
 test:
   imports:
     - contourpy
     - contourpy.util
-  requires:
-    - pip
   commands:
     - pip check
-    - python -c "import contourpy as c; c.contour_generator(z=[[0, 1], [2, 3]]).lines(0.9)"
+    - python -c "import contourpy as c; print(c.contour_generator(z=[[0, 1], [2, 3]]).lines(0.9))"
+    - python -c "from contourpy.util import build_config; from pprint import pprint; pprint(build_config())"
+    - python -c "import platform, sys; print(sys.version, platform.uname())"
+  requires:
+    - pip
 
 about:
   home: https://github.com/contourpy/contourpy


### PR DESCRIPTION
Update ContourPy to 1.2.0, in line with conda-forge. This will be needed for the 3.4 release of Bokeh.

Most of the changes here are due to switching to use `meson` to build `contourpy`.