### PR TITLE
ensure numpy 2 compat

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "contourpy" %}
-{% set version = "1.3.1" %}
+{% set version = "1.2.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/contourpy-{{ version }}.tar.gz
-  sha256: dfd97abd83335045a913e3bcc4a09c0ceadbe66580cf573fe961f4a825efa699
+  sha256: 4d8908b3bee1c889e547867ca4cdc54e5ab6be6d3e078556814a22457f49423c
 
 build:
   number: 1
-  skip: true  # [py<310]
+  skip: true  # [py<39]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   missing_dso_whitelist:  # [s390x]
     - $RPATH/ld64.so.1    # [s390x]
@@ -21,13 +21,13 @@ requirements:
     - {{ compiler('cxx') }}
   host:
     - pip
-    - meson >=1.2.0
-    - pybind11 >=2.13.2,!=2.13.3
+    - meson ==1.2.1
+    - meson-python ==0.13.1
+    - pybind11 ==2.10.4
     - python
-    - meson-python >=0.13.1
   run:
     - python
-    - numpy >=2.0.0, <2.3.0
+    - numpy >=1.23
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: dfd97abd83335045a913e3bcc4a09c0ceadbe66580cf573fe961f4a825efa699
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<310]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   missing_dso_whitelist:  # [s390x]
@@ -27,7 +27,7 @@ requirements:
     - meson-python >=0.13.1
   run:
     - python
-    - numpy >=1.23
+    - numpy >=2.0.0, <2.3.0
 
 test:
   imports:


### PR DESCRIPTION
contour-py 
defaults

### Links

- [PKG-6845](https://anaconda.atlassian.net/browse/PKG-6845) 
- [Upstream repository](https://github.com/contourpy/contourpy)
- [Upstream changelog/diff](https://github.com/contourpy/contourpy)
- Relevant dependency PRs:
  - ...

### Explanation of changes:

- numpy 2 compat


[PKG-6845]: https://anaconda.atlassian.net/browse/PKG-6845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ